### PR TITLE
Require rack-mini-profiler in bookend

### DIFF
--- a/lib/perf_utils/bookend.rb
+++ b/lib/perf_utils/bookend.rb
@@ -1,6 +1,7 @@
 require 'objspace'
 require 'singleton'
 require 'json'
+require 'rack-mini-profiler'
 require 'perf_utils/rack_storage'
 require 'perf_utils/printer'
 


### PR DESCRIPTION
Because I am lazy and don't want to require it myself everytime I am using bookend :smile:
